### PR TITLE
Improve hero draw reveal and prune placeholders

### DIFF
--- a/Key-Combat-AI/data/characters.js
+++ b/Key-Combat-AI/data/characters.js
@@ -4,39 +4,6 @@
 
 window.charactersData = [
   {
-    id: 'hero_fire_knight',
-    name: 'Blazing Knight',
-    type: 'Attack',
-    baseHP: 100,
-    baseAttack: 20,
-    passive: 'Burning Aura: Adds small burn damage over time',
-    key: 'e',
-    ultChargeNeeded: 5,
-    ultEffect: 'Deals massive fire damage'
-  },
-  {
-    id: 'hero_healer',
-    name: 'Sacred Healer',
-    type: 'Support',
-    baseHP: 80,
-    baseAttack: 10,
-    passive: 'Heal on Combo: Heals team slightly on perfect combos',
-    key: 'r',
-    ultChargeNeeded: 4,
-    ultEffect: 'Heals entire team to full'
-  },
-  {
-    id: 'hero_shadow_rogue',
-    name: 'Shadow Rogue',
-    type: 'Attack',
-    baseHP: 70,
-    baseAttack: 25,
-    passive: 'Critical Strike: Chance to deal double damage',
-    key: 't',
-    ultChargeNeeded: 6,
-    ultEffect: 'Unleashes a flurry of strikes'
-  },
-  {
     id: 'hero_azal',
     name: 'Azal',
     type: 'Attack',


### PR DESCRIPTION
## Summary
- remove placeholder heroes with missing art from character roster
- add image-cached card reveal flow with fade-in stats and duplicate upgrade display
- ensure runs and gacha only use heroes with art assets

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d072442908329ae13272ac2ff9d88